### PR TITLE
fastsizer: support the JPEG orientation tag

### DIFF
--- a/lib/image/fastsizer/fastimage_test.go
+++ b/lib/image/fastsizer/fastimage_test.go
@@ -20,6 +20,19 @@ func BenchmarkJpeg(b *testing.B) {
 	f.Close()
 }
 
+func BenchmarkJpegInfo(b *testing.B) {
+	f, err := os.Open("test.jpg")
+	if err != nil {
+		panic(fmt.Sprintf("error loading: %s", err))
+	}
+	fi := NewFastSizer()
+	for i := 0; i < b.N; i++ {
+		f.Seek(0, io.SeekStart)
+		fi.DetectInfo(f)
+	}
+	f.Close()
+}
+
 /*
 
 import (

--- a/lib/image/fastsizer/image_size.go
+++ b/lib/image/fastsizer/image_size.go
@@ -5,3 +5,27 @@ type ImageSize struct {
 	Width  uint32
 	Height uint32
 }
+
+type MirrorDirection int
+
+const (
+	MirrorNone MirrorDirection = iota
+	MirrorHorizontal
+	MirrorVertical
+)
+
+func (info ImageInfo) RotatedSize() ImageSize {
+	switch info.Rotation {
+	case 0:
+		fallthrough
+	case 180:
+		return info.Size
+	case 90:
+		fallthrough
+	case 270:
+		return ImageSize{info.Size.Height, info.Size.Width}
+	default:
+		// Not supported..
+		return info.Size
+	}
+}

--- a/lib/image/fastsizer/jpeg.go
+++ b/lib/image/fastsizer/jpeg.go
@@ -1,24 +1,29 @@
 package fastsizer
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 )
 
-func (f *decoder) getJPEGImageSize() (ImageSize, error) {
+func (f *decoder) getJPEGInfo(info *ImageInfo) error {
 	offset := 2
 	var err error
 	tmp := make([]byte, 2)
 	for {
 		tmp, err = f.reader.Slice(offset, 2)
 		if err != nil {
-			return ImageSize{}, err
+			return err
 		}
 		offset += 2
 		for tmp[0] != 0xff {
 			tmp[0] = tmp[1]
 			tmp[1], err = f.reader.ReadByte()
 			if err != nil {
-				return ImageSize{}, err
+				return err
 			}
 			offset++
 		}
@@ -29,7 +34,7 @@ func (f *decoder) getJPEGImageSize() (ImageSize, error) {
 		for marker == 0xff {
 			marker, err = f.reader.ReadByte()
 			if err != nil {
-				return ImageSize{}, err
+				return err
 			}
 			offset++
 		}
@@ -41,12 +46,12 @@ func (f *decoder) getJPEGImageSize() (ImageSize, error) {
 		}
 		_, err = f.reader.ReadFull(tmp)
 		if err != nil {
-			return ImageSize{}, err
+			return err
 		}
 		offset += 2
 		n := int(tmp[0])<<8 + int(tmp[1]) - 2
 		if n < 0 {
-			return ImageSize{}, fmt.Errorf("short segment length")
+			return fmt.Errorf("short segment length")
 		}
 		switch marker {
 		case sof0Marker, sof1Marker, sof2Marker:
@@ -54,18 +59,26 @@ func (f *decoder) getJPEGImageSize() (ImageSize, error) {
 			if err == nil {
 				if tmp[0] != 8 {
 					err = fmt.Errorf("only support 8-bit precision")
-					return ImageSize{}, err
+					return err
 				} else {
-					return ImageSize{
+					info.Size = ImageSize{
 						Width:  uint32(int(tmp[3])<<8 + int(tmp[4])),
 						Height: uint32(int(tmp[1])<<8 + int(tmp[2])),
-					}, nil
+					}
+					return nil
 				}
 			}
 		case dhtMarker, dqtMarker, driMarker, app0Marker, app14Marker:
 			offset += n
 		case sosMarker:
-			return ImageSize{}, fmt.Errorf("meet sos marker")
+			return fmt.Errorf("meet sos marker")
+		case app1Marker:
+			if !f.minimal {
+				if err := f.readExif(info, offset, n); err != nil && err != errNotExif {
+					return err
+				}
+			}
+			offset += n
 		default:
 			if app0Marker <= marker && marker <= app15Marker || marker == comMarker {
 				offset += n
@@ -76,10 +89,129 @@ func (f *decoder) getJPEGImageSize() (ImageSize, error) {
 			}
 		}
 		if err != nil {
-			return ImageSize{}, err
+			return err
 		}
 	}
-	return ImageSize{}, fmt.Errorf("fail get size")
+	return fmt.Errorf("fail get size")
+}
+
+var errNotExif = errors.New("not exif")
+
+// Adapted from https://github.com/disintegration/imageorient/
+func (f *decoder) readExif(info *ImageInfo, offs, n int) error {
+	// EXIF marker
+	const (
+		markerSOI      = 0xffd8
+		markerAPP1     = 0xffe1
+		exifHeader     = 0x45786966
+		byteOrderBE    = 0x4d4d
+		byteOrderLE    = 0x4949
+		orientationTag = 0x0112
+	)
+
+	// XXX This is a lazy way to avoid rewriting the logic
+	buf := make([]byte, n)
+	if _, err := f.reader.ReadFull(buf); err != nil {
+		return err
+	}
+	r := bytes.NewBuffer(buf)
+
+	// Check if EXIF header is present.
+	var header uint32
+	if err := binary.Read(r, binary.BigEndian, &header); err != nil {
+		return err
+	}
+	if header != exifHeader {
+		return errNotExif
+	}
+	if _, err := io.CopyN(ioutil.Discard, r, 2); err != nil {
+		return err
+	}
+
+	// Read byte order information.
+	var (
+		byteOrderTag uint16
+		byteOrder    binary.ByteOrder
+	)
+	if err := binary.Read(r, binary.BigEndian, &byteOrderTag); err != nil {
+		return err
+	}
+	switch byteOrderTag {
+	case byteOrderBE:
+		byteOrder = binary.BigEndian
+	case byteOrderLE:
+		byteOrder = binary.LittleEndian
+	default:
+		return errors.New("invalid byte order")
+	}
+	if _, err := io.CopyN(ioutil.Discard, r, 2); err != nil {
+		return err
+	}
+
+	// Skip the EXIF offset.
+	var offset uint32
+	if err := binary.Read(r, byteOrder, &offset); err != nil {
+		return err
+	}
+	if offset < 8 {
+		return errors.New("invalid EXIF offset")
+	}
+	if _, err := io.CopyN(ioutil.Discard, r, int64(offset-8)); err != nil {
+		return err
+	}
+
+	// Read the number of tags.
+	var numTags uint16
+	if err := binary.Read(r, byteOrder, &numTags); err != nil {
+		return err
+	}
+
+	// Find the orientation tag.
+	for i := 0; i < int(numTags); i++ {
+		var tag uint16
+		if err := binary.Read(r, byteOrder, &tag); err != nil {
+			return err
+		}
+		if tag != orientationTag {
+			if _, err := io.CopyN(ioutil.Discard, r, 10); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := io.CopyN(ioutil.Discard, r, 6); err != nil {
+			return err
+		}
+		var val uint16
+		if err := binary.Read(r, byteOrder, &val); err != nil {
+			return err
+		}
+		if val < 0 || val > 8 {
+			return fmt.Errorf("invalid orientation tag (%d)", val)
+		}
+
+		switch val {
+		case 2:
+			info.Mirror = MirrorHorizontal
+		case 3:
+			info.Rotation = 180
+		case 4:
+			info.Mirror = MirrorVertical
+		case 5:
+			info.Mirror = MirrorHorizontal
+			fallthrough
+		case 8:
+			info.Rotation = 270
+		case 7:
+			info.Mirror = MirrorHorizontal
+			fallthrough
+		case 6:
+			info.Rotation = 90
+		}
+
+		return nil
+	}
+
+	return nil
 }
 
 const (
@@ -99,6 +231,7 @@ const (
 	// but in practice, their use is described at
 	// http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/JPEG.html
 	app0Marker  = 0xe0
+	app1Marker  = 0xe1
 	app14Marker = 0xee
 	app15Marker = 0xef
 )


### PR DESCRIPTION
Adds a DetectInfo method, which returns an ImageInfo with more detail
than the minimal Detect method.

For JPEG, read exif orientation for ImageInfo, which can return the
rotated size.